### PR TITLE
Alias: Season 6

### DIFF
--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -5,52 +5,65 @@ open = require 'open'
 
 argv = require 'yargs'
   .option 'short',
+    alias: 's'
     type: 'boolean'
     default: undefined
     describe: "Short output: show browsers on one line and don't display notes or description (default when displaying multiple results)"
   .option 'long',
+    alias: 'l'
     type: 'boolean'
     default: undefined
     describe: "Long output: show more information (default when displaying a single result)"
   .option 'oneline',
+    alias: '1'
     type: 'boolean'
     default: false
     describe: "One-line output: just global percentages, no per-browser info"
   .option 'oneline-browser',
+    alias: '2'
     type: 'boolean'
     default: false
     describe: "One-line output with browser info, implies --abbrev and --current"
   .option 'abbrev',
+    alias: 'a'
     type: 'boolean'
     default: false
     describe: "Abbreviate browser names"
   .option 'percentages',
+    alias: 'p'
     type: 'boolean'
     default: false
     describe: "Include browser version usage percentages"
   .option 'future',
+    alias: 'f'
     type: 'boolean'
     default: false
     describe: "Include future browser versions"
   .option 'current',
+    alias: 'c'
     type: 'boolean'
     default: false
     describe: "Don't include old browser versions, equivalent to --era e0"
   .option 'era',
+    alias: 'e'
     type: 'string'
     describe: "How many versions back to go, e0 to #{Object.keys(data.eras)[0]}"
   .option 'mobile',
+    alias: 'm'
     type: 'boolean'
     default: false
     describe: "Include mobile browsers"
   .option 'desktop',
+    alias: 'd'
     type: 'boolean'
     default: true
     describe: "Include desktop browsers"
   .option 'browser',
+    alias: 'b'
     type: 'string'
     describe: "Show results for these browsers, comma-separated (#{Object.keys(data.agents)})"
   .option 'web',
+    alias: 'w'
     type: 'boolean'
     default: false
     describe: "Go to the search page on caniuse.com"


### PR DESCRIPTION
![](http://www.ezthemes.com/previews/a/alias1.jpg)

#### Add some aliases to make the options a bit quicker to get to.

Here is a screenshot of what the new help print out looks like:

![screen shot 2015-08-03 at 1 51 12 pm](https://cloud.githubusercontent.com/assets/724087/9043986/7ee3ae64-39e7-11e5-9404-5bc6185fbc45.png)

**Note:** I wasn't quite sure what to do when it came to `oneline` and `oneline-browser`, so I just sort of improvised haha. Definitely open to ideas around that.