### PR TITLE
Fix typo in displaying partial support percentage.

### DIFF
--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -160,7 +160,7 @@ showFeature = (result, opts={}) ->
 
   percentages = []
   percentages.push "✔ #{result.usage_perc_y}%".green if result.usage_perc_y
-  percentages.push "◒ #{result.usage_perc_a}%".yellow if result.usage_perc_y
+  percentages.push "◒ #{result.usage_perc_a}%".yellow if result.usage_perc_a
   percentages = percentages.join(' ')
 
   status = if opts.long then " [#{data.statuses[result.status]}]" else ''


### PR DESCRIPTION
If there are no browsers that fully support a feature and at least one browser that partially supports the feature, that partial support percentage is not shown.

Fixes https://github.com/sgentle/caniuse-cmd/issues/3