### PR TITLE
Fixing unicode characters at Windows environments

### DIFF
--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -4,6 +4,7 @@ linewrap = require 'linewrap'
 open = require 'open'
 path = require 'path'
 osHomedir = require 'os-homedir'
+os = require('os')
 
 argv = require 'yargs'
   .option 'short',
@@ -85,6 +86,9 @@ argv = require 'yargs'
 
 resultmap = y: "✔", n: "✘", a: "◒", u: "‽", i: "ⓘ", w: "⚠"
 supernums = "⁰¹²³⁴⁵⁶⁷⁸⁹"
+
+if (os.platform() == 'win32')
+  resultmap = y: "\u221A", n: "\u00D7", a: "\u0473", u: "?", i: "\u24D8", w: "\u26A0"
 
 if argv["ascii"]
   resultmap = y: "[Yes]", n: "[No]", a: "[Partly]", u: "[?!]", i: "[Info]", w: "[Warning]"

--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -4,7 +4,7 @@ linewrap = require 'linewrap'
 open = require 'open'
 path = require 'path'
 osHomedir = require 'os-homedir'
-os = require('os')
+os = require 'os'
 
 argv = require 'yargs'
   .option 'short',

--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -88,7 +88,7 @@ resultmap = y: "✔", n: "✘", a: "◒", u: "‽", i: "ⓘ", w: "⚠"
 supernums = "⁰¹²³⁴⁵⁶⁷⁸⁹"
 
 if (os.platform() == 'win32')
-  resultmap = y: "\u221A", n: "\u00D7", a: "\u0473", u: "?", i: "\u24D8", w: "\u26A0"
+  resultmap = y: "\u221A", n: "\u00D7", a: "\u0473", u: "\u203D", i: "\u24D8", w: "\u26A0"
 
 if argv["ascii"]
   resultmap = y: "[Yes]", n: "[No]", a: "[Partly]", u: "[?!]", i: "[Info]", w: "[Warning]"


### PR DESCRIPTION
Fixing #4 

![caniuse_winfix](https://cloud.githubusercontent.com/assets/37474/13037787/9f38e338-d36f-11e5-9fba-6689886d71ee.PNG)

Fix with same logic than https://github.com/mochajs/mocha/pull/641
Tested in Win10 environment.
