### PR TITLE
refs #14 Change supers color, add spaces

### DIFF
--- a/caniuse.coffee
+++ b/caniuse.coffee
@@ -145,7 +145,7 @@ makeResult = (result, nums={}) ->
   out += "ᵖ" if "x" in result.support
   if note = result.support.match(/#(\d+)/)?[1]
     nums[note] = true
-    out += supernums[note]
+    out += supernums[note].cyan
 
   if argv.percentages and result.usage
     out += " " unless out.slice(-1) is "\u2800"
@@ -230,8 +230,8 @@ showFeature = (result, opts={}) ->
 
   unless opts.short
     for num, note of result.notes_by_num when need_note[num]
-      console.log wrap "\t\t#{supernums[num].yellow}#{note}"
-    console.log wrap "\t " + resultmap.i + "  #{result.notes.replace(/[\r\n]+/g, ' ')}" if result.notes
+      console.log wrap "\t\t#{supernums[num].cyan} #{note}"
+    console.log wrap "\t #{resultmap.i}  #{result.notes.replace(/[\r\n]+/g, ' ')}" if result.notes
 
 
 slowFind = (query) ->


### PR DESCRIPTION
This PR introduces a fix required in #14.

With this changes the output will be like this:
![image](https://user-images.githubusercontent.com/15163823/30036085-1d9a57be-91c1-11e7-953d-d39046109b2f.png)

I also experimented with spaces between versions and supers, but they seem too large:
![image](https://user-images.githubusercontent.com/15163823/30036131-8b278838-91c1-11e7-9b0b-7df964189dce.png)
So I decided to leave a version without spaces between versions and supers.