### PR TITLE
Add the packaging metadata to build the caniuse snap

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,18 @@
+name: caniuse
+version: git
+summary: Caniuse command line tool
+description: |
+ Just what you've always wanted, it's a caniuse command line tool! All the power of caniuse.com with none of the nice UI or interactivity!
+
+grade: stable
+confinement: strict
+
+apps:
+  caniuse:
+    command: caniuse
+    plugs: [network]
+
+parts:
+  caniuse:
+    source: .
+    plugin: nodejs


### PR DESCRIPTION
This package will let you publish the latest caniuse in the Ubuntu store, and from there reach many users on all the supported Ubuntu versions, and Linux distributions. You just have to go to https://build.snapcraft.io and enable the automated continuous delivery.

It was packaged and released to the store by @DavidResendizz during [google code-in](https://codein.withgoogle.com/). So, when you try to register the name you will find that it is already taken. You just have to fill the form claiming that you are the upstream developer, and we will take care of the transfer.